### PR TITLE
Removed dependency to pololu/fastgpio-arduino (was not required)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
-name=RasPiBot202.V2
+name=RasPiBot202V2
 version=0.0.1
-author=Julien de la Bruere-Terreault
-maintainer=Julien de la Bruere-Terreault <drgfreeman@tuta.io>
+author=Julien de la Bruere-Terreault, drgfreeman@tuta.io
+maintainer=Julien de la Bruere-Terreault, drgfreeman@tuta.io
 sentence=RasPiBot202 Robot Arduino Library
 paragraph=A simple differential drive robot project based on Pololu Romi chassis and A-Star 32U4 SV w Raspberry Pi bridge.
 category=Device Control

--- a/src/AStarEncoders.cpp
+++ b/src/AStarEncoders.cpp
@@ -81,10 +81,10 @@ static void rightISR()
 AStarEncoders::AStarEncoders()
 {
   // Set encoder pins mode
-  FastGPIO::Pin<LEFT_A>::setInputPulledUp();
-  FastGPIO::Pin<LEFT_B>::setInputPulledUp();
-  FastGPIO::Pin<RIGHT_A>::setInputPulledUp();
-  FastGPIO::Pin<RIGHT_B>::setInputPulledUp();
+  pinMode(LEFT_A, INPUT_PULLUP);
+  pinMode(LEFT_B, INPUT_PULLUP);
+  pinMode(RIGHT_A, INPUT_PULLUP);
+  pinMode(RIGHT_B, INPUT_PULLUP);
 
   // Enable PCINT4 & PCINT2; set 1 in PCMSK0 register bits 4 & 2
   PCMSK0 |= (1 << PCINT4);

--- a/src/AStarEncoders.h
+++ b/src/AStarEncoders.h
@@ -35,7 +35,6 @@ Pololu AStar 32U4 microcontroller.
 
 #include <Arduino.h>
 #include <AStar32U4.h>
-#include <FastGPIO.h>
 
 class AStarEncoders
 {


### PR DESCRIPTION
Removed dependency to pololu/fastgpio-arduino library which was not required anymore. Replaced by Arduino pinMode command in setup().
Also corrected the library name in the library.properties file to match the GitHub repository.